### PR TITLE
Tint_from_hue fix

### DIFF
--- a/lib/spittoon.rb
+++ b/lib/spittoon.rb
@@ -1136,7 +1136,7 @@ module Magick
     end
 
     def tint_from_hue(hue, intensity=1.0)
-      pixel = Pixel.from_HSL([hue, 1.0, 0.5])
+      pixel = Pixel.from_hsla(hue, 1.0, 0.5)
       return self.tint(pixel, intensity)
     end
 

--- a/spittoon.gemspec
+++ b/spittoon.gemspec
@@ -1,0 +1,10 @@
+Gem::Specification.new do |s|
+  s.name        = 'spittoon'
+  s.version     = '0.1.0'
+  s.summary     = 'Sequential-art comic-strip generator'
+  s.description = 'Spittoon is a comic strip generator. It is an implementation of the Microsoft Comic Chat algorithm described in the paper, Comic Chat by Kurlander, Skelly, and Salesin'
+  s.authors     = ['Ian Langworth']
+  s.files       = ['lib/spittoon.rb', 'lib/usage_helper.rb']
+  s.add_runtime_dependency 'rmagick', '~> 2.0', '>= 2.0.0'
+  s.license       = 'MIT'
+end


### PR DESCRIPTION
I've added a gemspec and fixed `tint_from_hue` to work with recent versions of rmagick